### PR TITLE
.jpeg -> .webp 를 위한 jacketLink url 수정 코드 추가

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -56,6 +56,9 @@ function RecommendSong() {
     
     // 자켓, level, 수록일, 곡명 선택
     var jacketLink = imgBaseUrl + selectedSong['jacket_link'];
+    // 로딩시간 단축을 위해 .jpeg -> .webp 로 변경
+    jacketLink = jacketLink.replace('illust', 'illust_webp');
+    jacketLink = jacketLink.replace('.jpeg', '.webp');
 
     // level은 이미 정의됨
     var difficulty = selectedSong['difficulty'];


### PR DESCRIPTION
.jpeg 보다 용량이 적은 .webp를 불러오도록 해 비교적 적은 지연시간을 기대할 수 있게 되었습니다.
![image](https://user-images.githubusercontent.com/25370441/144562979-287575c3-4b9c-41e5-aa95-177bd744320a.png)
